### PR TITLE
Issue is cordova build error of my app created cdp boilerplate

### DIFF
--- a/templates/mobile/_gitignore
+++ b/templates/mobile/_gitignore
@@ -8,7 +8,7 @@ npm-debug.log
 *.csproj.user
 *.suo
 
-# project ignores
+# project ignores (common)
 !.gitkeep
 .vs/
 .sass-cache/
@@ -17,10 +17,14 @@ node_modules/
 bin/
 obj/
 temp/
-www/
-platforms/*/www/
-platforms/*/assets/www/
-platforms/*/{{structureConfig.porting}}/**/*.js
-{{structureConfig.built}}/**/*.js
-{{structureConfig.built}}/**/*.map
-{{structureConfig.test}}/unit/**/*.js
+
+# project ignores (under root directory)
+/www/
+/platforms/*/www/
+/platforms/*/assets/www/
+/platforms/*/{{structureConfig.porting}}/**/*.js
+!/platforms/android/cordova/node_modules/
+!/platforms/ios/cordova/node_modules/
+/{{structureConfig.built}}/**/*.js
+/{{structureConfig.built}}/**/*.map
+/{{structureConfig.test}}/unit/**/*.js


### PR DESCRIPTION
My app was created by "cdp create mobile" command of cdp-cli.
I commited these sources of the condition that it was created  to GitHub.

I cloned cource from GitHub to local and execute the following command with current directory of the sources.

1. npm installl
2. npm run build:debug
3. cordova build android (or cordova build ios)

The cordova build is error.
Because there are no "/platforms/<platform>/cordova/node_modules".

So I modified sources of cdp-lib as pull request.
Please confirm the following:
- Added not ignore path to "/templates/mobile/_gitignore" into cdp-lib.

And incidentally, I modified the following item.
- Added "/" to top of some ignore path.

Best regard.